### PR TITLE
publishEvent is no longer in private beta

### DIFF
--- a/examples/node/publish-event.js
+++ b/examples/node/publish-event.js
@@ -4,7 +4,6 @@
 var spark = require('spark');
 
 spark.on('login', function() {
-  //This feature is in a limited beta, and is not yet generally available
   var publishEventPr = spark.publishEvent('test', {});
 
   publishEventPr.then(


### PR DESCRIPTION
The ability to publish an event from particle-cli or sparkjs is no longer restricted to private beta users.